### PR TITLE
Pushing README and fix to my_sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 This the GitHub repository for the CSE 183 group project Study Group Finder
 
 https://docs.google.com/document/d/1Gpamef4ucTcBGNDhcggP2LYN_NMjIUE7RVSJzm1c3d8/edit?usp=sharing
+
+## Installation/Usage Instructions
+
+## Known Issues
+
+#### Toggle enroll and unenroll button (In find_sessions page)
+- When going from unenroll to enroll (clicking on red unenroll button) the result changes dynamically on screen (without needing to refresh the page).
+- However, when going from enroll to unenroll (clicking on green enroll button) the results are not reflected until after refreshing the page.
+

--- a/controllers.py
+++ b/controllers.py
@@ -286,10 +286,10 @@ def find_session():
         session.is_enrolled = bool(enrollment)
 
         # Print the value of is_enrolled for each session
-        print(f"Session {session.id} - is_enrolled: {session.is_enrolled}")
+        # print(f"Session {session.id} - is_enrolled: {session.is_enrolled}")
 
     # Print the content of sessions
-    print(sessions)
+    # print(sessions)
 
 
     return dict(

--- a/templates/my_sessions.html
+++ b/templates/my_sessions.html
@@ -5,10 +5,15 @@
         My Sessions
     </h3>
 
+
 <!--    results-->
 
     <div class="block">
-        <table class="table is-hoverable has-text-weight-light">
+        <div v-if="enrolled_sessions.length < 1"
+          class="has-text-grey-lighter" >
+          Not enrolled in any sessions
+        </div>
+        <table v-else class="table is-hoverable has-text-weight-light">
       <thead>
         <tr>
           <td></td>


### PR DESCRIPTION
When there are no sessions the user is enrolled into, the page will share that the user is not enrolled in any sessions (instead of showing an empty table with column headers).